### PR TITLE
Expr block

### DIFF
--- a/deps/pkl/Memory.pkl
+++ b/deps/pkl/Memory.pkl
@@ -8,11 +8,6 @@ open module org.kdeps.pkl.Memory
 import "package://pkg.pkl-lang.org/pkl-go/pkl.golang@0.9.0#/go.pkl"
 import "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.uri@1.0.3#/URI.pkl"
 
-/// Class representing a memory item
-class MemoryRecord {
-  value: String?
-}
-
 /// Retrieves a memory item by its [id]
 ///
 /// Returns the textual content of the memory entry, or an empty string if not found.

--- a/deps/pkl/Resource.pkl
+++ b/deps/pkl/Resource.pkl
@@ -69,54 +69,57 @@ run: ResourceAction
 
 /// Class representing an action that can be executed on a resource.
 class ResourceAction {
-    /// Configuration for executing commands.
-    exec: Exec.ResourceExec?
+        /// Block for performing PKL expressions.
+        expr: Dynamic?
 
-    /// Configuration for python scripts.
-    python: Python.ResourcePython?
+        /// Configuration for executing commands.
+        exec: Exec.ResourceExec?
 
-    /// Configuration for chat interactions with an LLM.
-    chat: LLM.ResourceChat?
+        /// Configuration for python scripts.
+        python: Python.ResourcePython?
 
-    /// A listing of conditions that determine if the action should be skipped.
-    skipCondition: Listing<Any>?
+        /// Configuration for chat interactions with an LLM.
+        chat: LLM.ResourceChat?
 
-    /// A pre-flight validation check to be performed before executing the action.
-    preflightCheck: ValidationCheck?
+        /// A listing of conditions that determine if the action should be skipped.
+        skipCondition: Listing<Any>?
 
-    /// A listing of allowed HTTP headers
-    allowedHeaders: Listing<String>?
+        /// A pre-flight validation check to be performed before executing the action.
+        preflightCheck: ValidationCheck?
 
-    /// A listing of allowed HTTP params
-    allowedParams: Listing<String>?
+        /// A listing of allowed HTTP headers
+        allowedHeaders: Listing<String>?
 
-    /// A listing of targeted HTTP methods
-    restrictToHTTPMethods: Listing<String>?
+        /// A listing of allowed HTTP params
+        allowedParams: Listing<String>?
 
-    /// A listing of targeted HTTP routes
-    restrictToRoutes: Listing<String>?
+        /// A listing of targeted HTTP methods
+        restrictToHTTPMethods: Listing<String>?
 
-    /// Configuration for HTTP client interactions.
-    HTTPClient: HTTP.ResourceHTTPClient?
+        /// A listing of targeted HTTP routes
+        restrictToRoutes: Listing<String>?
 
-    /// Configuration for handling API responses.
-    APIResponse: APIServerResponse?
+        /// Configuration for HTTP client interactions.
+        HTTPClient: HTTP.ResourceHTTPClient?
+
+        /// Configuration for handling API responses.
+        APIResponse: APIServerResponse?
 }
 
 /// Class representing validation checks that can be performed on actions.
 class ValidationCheck {
-    /// A listing of validation conditions.
-    validations: Listing<Any>?
+        /// A listing of validation conditions.
+        validations: Listing<Any>?
 
-    /// An error associated with the validation check, if any.
-    error: APIError?
+        /// An error associated with the validation check, if any.
+        error: APIError?
 }
 
 /// Class representing an error returned from an API validation check.
 class APIError {
-    /// The error code associated with the API error.
-    code: Int
+        /// The error code associated with the API error.
+        code: Int
 
-    /// A message providing details about the error.
-    message: String
+        /// A message providing details about the error.
+        message: String
 }

--- a/gen/memory/MemoryRecord.pkl.go
+++ b/gen/memory/MemoryRecord.pkl.go
@@ -1,7 +1,0 @@
-// Code generated from Pkl module `org.kdeps.pkl.Memory`. DO NOT EDIT.
-package memory
-
-// Class representing a memory item
-type MemoryRecord struct {
-	Value *string `pkl:"value"`
-}

--- a/gen/memory/init.pkl.go
+++ b/gen/memory/init.pkl.go
@@ -5,5 +5,4 @@ import "github.com/apple/pkl-go/pkl"
 
 func init() {
 	pkl.RegisterMapping("org.kdeps.pkl.Memory", MemoryImpl{})
-	pkl.RegisterMapping("org.kdeps.pkl.Memory#MemoryRecord", MemoryRecord{})
 }

--- a/gen/resource/ResourceAction.pkl.go
+++ b/gen/resource/ResourceAction.pkl.go
@@ -2,6 +2,7 @@
 package resource
 
 import (
+	"github.com/apple/pkl-go/pkl"
 	"github.com/kdeps/schema/gen/api_server_response"
 	"github.com/kdeps/schema/gen/exec"
 	"github.com/kdeps/schema/gen/http"
@@ -11,6 +12,9 @@ import (
 
 // Class representing an action that can be executed on a resource.
 type ResourceAction struct {
+	// Block for performing PKL expressions.
+	Expr *pkl.Object `pkl:"expr"`
+
 	// Configuration for executing commands.
 	Exec *exec.ResourceExec `pkl:"exec"`
 


### PR DESCRIPTION
The `expr` block allows evaluation of any standard PKL expression on a resource. It is primarily used for expressions that produce side effects, such as setter functions.

**Example:**

```pkl
expr {
  "@(memory.setItem("foo", "bar"))"
}
```

In this case, `memory.setItem` updates the resource but does not return a meaningful value. Hence, there’s no need to wrap it in a lazily evaluated string. The `expr` block exists specifically for executing such side-effecting expressions.

Additionally, because any valid PKL expression can be used, the `expr` block also serves as a lightweight scripting mechanism—useful for crafting inline logic, conditional assignments, and procedural-style workflows within your workflow configuration.