### PR TITLE
import on amends upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,4 +524,4 @@ Kdeps is an AI Agent framework for building self-hosted RAG AI Agents powered by
   - **Initial commit** (`26d33e0`)
 
 ---
-*Generated on 2025-07-09 16:18:14 by [Enhanced Release Notes Generator](scripts/generate_release_notes.sh)*
+*Generated on 2025-07-10 01:28:28 by [Enhanced Release Notes Generator](scripts/generate_release_notes.sh)*

--- a/assets/pkl/Resource.pkl
+++ b/assets/pkl/Resource.pkl
@@ -20,6 +20,7 @@ import "pkl:semver"
 import "pkl:shell"
 import "pkl:xml"
 import "pkl:yaml"
+
 import "Document.pkl" as document
 import "Utils.pkl" as utils
 import "Memory.pkl" as memory
@@ -27,13 +28,16 @@ import "Session.pkl" as session
 import "Tool.pkl" as tool
 import "Item.pkl" as item
 
+import "LLM.pkl" as llm
+import "Agent.pkl" as agent
+import "Python.pkl" as python
+import "Exec.pkl" as exec
+import "HTTP.pkl" as client
+import "APIServerRequest.pkl" as request
+
 import "Project.pkl"
 import "APIServer.pkl"
 import "APIServerResponse.pkl"
-import "LLM.pkl"
-import "Exec.pkl"
-import "Python.pkl"
-import "HTTP.pkl"
 
 /// Regex pattern for validating resource actionIDs and dependencies.
 hidden actionStringRegex = Regex(#"^(\w+|@\w+(/[\w-]+)(:[\w.]+)?)$"#)
@@ -79,13 +83,13 @@ class ResourceAction {
         Expr: Dynamic?
 
         /// Configuration for executing commands.
-        Exec: Exec.ResourceExec?
+        Exec: exec.ResourceExec?
 
         /// Configuration for python scripts.
-        Python: Python.ResourcePython?
+        Python: python.ResourcePython?
 
         /// Configuration for chat interactions with an LLM.
-        Chat: LLM.ResourceChat?
+        Chat: llm.ResourceChat?
 
         /// A listing of conditions that determine if the action should be skipped.
         SkipCondition: Listing<Any>?
@@ -109,7 +113,7 @@ class ResourceAction {
         RestrictToRoutes: Listing<String>?
 
         /// Configuration for HTTP client interactions.
-        HTTPClient: HTTP.ResourceHTTPClient?
+        HTTPClient: client.ResourceHTTPClient?
 
         /// Configuration for handling API responses.
         APIResponse: APIServerResponse?

--- a/deps/pkl/Resource.pkl
+++ b/deps/pkl/Resource.pkl
@@ -20,6 +20,7 @@ import "pkl:semver"
 import "pkl:shell"
 import "pkl:xml"
 import "pkl:yaml"
+
 import "Document.pkl" as document
 import "Utils.pkl" as utils
 import "Memory.pkl" as memory
@@ -27,13 +28,16 @@ import "Session.pkl" as session
 import "Tool.pkl" as tool
 import "Item.pkl" as item
 
+import "LLM.pkl" as llm
+import "Agent.pkl" as agent
+import "Python.pkl" as python
+import "Exec.pkl" as exec
+import "HTTP.pkl" as client
+import "APIServerRequest.pkl" as request
+
 import "Project.pkl"
 import "APIServer.pkl"
 import "APIServerResponse.pkl"
-import "LLM.pkl"
-import "Exec.pkl"
-import "Python.pkl"
-import "HTTP.pkl"
 
 /// Regex pattern for validating resource actionIDs and dependencies.
 hidden actionStringRegex = Regex(#"^(\w+|@\w+(/[\w-]+)(:[\w.]+)?)$"#)
@@ -79,13 +83,13 @@ class ResourceAction {
         Expr: Dynamic?
 
         /// Configuration for executing commands.
-        Exec: Exec.ResourceExec?
+        Exec: exec.ResourceExec?
 
         /// Configuration for python scripts.
-        Python: Python.ResourcePython?
+        Python: python.ResourcePython?
 
         /// Configuration for chat interactions with an LLM.
-        Chat: LLM.ResourceChat?
+        Chat: llm.ResourceChat?
 
         /// A listing of conditions that determine if the action should be skipped.
         SkipCondition: Listing<Any>?
@@ -109,7 +113,7 @@ class ResourceAction {
         RestrictToRoutes: Listing<String>?
 
         /// Configuration for HTTP client interactions.
-        HTTPClient: HTTP.ResourceHTTPClient?
+        HTTPClient: client.ResourceHTTPClient?
 
         /// Configuration for handling API responses.
         APIResponse: APIServerResponse?


### PR DESCRIPTION
As part of deprecating the monkey @(...) template syntax. The goal is to call the functions directly without any interpolation. See: https://github.com/kdeps/kdeps/pull/55